### PR TITLE
`--set-limit` option 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,7 @@ Installation
           -t [ --toggle-mute ]  switch between mute and unmute
           -m [ --mute ]         set mute
           --allow-boost         allow volume to go above 100%
+          --set-limit arg       set a limit for the volume
           --gamma arg (=1)      increase/decrease using gamma correction e.g. 2.2
           -u [ --unmute ]       unset mute
           --get-mute            display true if the volume is mute, false otherwise

--- a/pamixer.cc
+++ b/pamixer.cc
@@ -151,19 +151,25 @@ int main(int argc, char* argv[])
                 new_value = gammaCorrection(device.volume_avg, gamma, -value);
             }
 
-            if (vm.count("set-limit")) {
-                pa_volume_t limit = round( (double)limit_value * (double)PA_VOLUME_NORM / 100.0);
-                if (new_value > limit) {
-                    new_value = limit;
-                }
-            }
-
             if (!vm.count("allow-boost") && new_value > PA_VOLUME_NORM) {
                 new_value = PA_VOLUME_NORM;
             }
 
             pulse.set_volume(device, new_value);
             device = get_selected_device(pulse, vm, sink_name, source_name);
+        }
+
+        if (vm.count("set-limit")) {
+
+            if (limit_value < 0 ) {
+                limit_value = 0;
+            }
+
+            pa_volume_t limit = round( (double)limit_value * (double)PA_VOLUME_NORM / 100.0);
+            if (device.volume_avg > limit) {
+                pulse.set_volume(device, limit);
+                device = get_selected_device(pulse, vm, sink_name, source_name);
+            }
         }
 
         if (vm.count("toggle-mute") || vm.count("mute") || vm.count("unmute")) {

--- a/pamixer.cc
+++ b/pamixer.cc
@@ -81,7 +81,7 @@ pa_volume_t gammaCorrection(pa_volume_t i, double gamma, int delta) {
 int main(int argc, char* argv[])
 {
     string sink_name, source_name;
-    int value;
+    int value, limit_value;
     double gamma;
 
     po::options_description options("Allowed options");
@@ -98,6 +98,7 @@ int main(int argc, char* argv[])
         ("toggle-mute,t", "switch between mute and unmute")
         ("mute,m", "set mute")
         ("allow-boost", "allow volume to go above 100%")
+        ("set-limit", po::value<int>(&limit_value), "set a limit for the volume")
         ("gamma", po::value<double>(&gamma)->default_value(1.0), "increase/decrease using gamma correction e.g. 2.2")
         ("unmute,u", "unset mute")
         ("get-mute", "display true if the volume is mute, false otherwise")
@@ -148,6 +149,13 @@ int main(int argc, char* argv[])
                 new_value = gammaCorrection(device.volume_avg, gamma,  value);
             } else if (vm.count("decrease")) {
                 new_value = gammaCorrection(device.volume_avg, gamma, -value);
+            }
+
+            if (vm.count("set-limit")) {
+                pa_volume_t limit = round( (double)limit_value * (double)PA_VOLUME_NORM / 100.0);
+                if (new_value > limit) {
+                    new_value = limit;
+                }
             }
 
             if (!vm.count("allow-boost") && new_value > PA_VOLUME_NORM) {


### PR DESCRIPTION
Let the user set a maximal volume. It's useful with `--allow-boost` to remove the danger of being at an insane high volume level.