### PR TITLE
Fix manpage install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,5 +27,5 @@ distclean: clean
 
 install: pamixer
 	install $(target) $(PREFIX)/bin/
-	install $(manpage) $(PREFIX)/man/man1/
+	install -TD $(manpage) $(PREFIX)/man/man1/$(manpage)
 	gzip $(PREFIX)/man/man1/$(manpage)


### PR DESCRIPTION
Hey @cdemoulins, thank you just merging my manpage addition. I just tested this on a fresh system and realised I made a mistake. The directory tree won't get created if it doesn't already exist. When I made this change I already had `/usr/local/man/man1` probably from some other thing I installed, but on this fresh system I didn't have `/usr/local/man` at all and of course it fails. This change fixes this.