### PR TITLE
Makefile: add support for DESTDIR in install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ distclean: clean
 	$(RM) $(target)
 
 install: pamixer
-	install $(target) $(PREFIX)/bin/
-	install $(manpage) $(PREFIX)/man/man1/
-	gzip $(PREFIX)/man/man1/$(manpage)
+	install -d $(DESTDIR)$(PREFIX)/bin/
+	install $(target) $(DESTDIR)$(PREFIX)/bin/
+	install -d $(DESTDIR)$(PREFIX)/man/man1/
+	install $(manpage) $(DESTDIR)$(PREFIX)/man/man1/
+	gzip $(DESTDIR)$(PREFIX)/man/man1/$(manpage)


### PR DESCRIPTION
hi,

for use in standard tools i added DESTDIR support to your install target in Makefile.

https://www.gnu.org/prep/standards/html_node/DESTDIR.html
(eg. to build debian packages)

(and created the directories when not already existing)