### PR TITLE
Replace boost program_optinos with cxxopts header only library

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,12 +8,12 @@ configure_file(output : 'config.hh', configuration : conf_data)
 configuration_inc = include_directories('.')
 
 pulse = dependency('libpulse')
-boost = dependency('boost', modules : 'program_options')
+cxxopts = dependency('cxxopts')
 
 executable('pamixer', 
   sources : src,
   install : true,
   include_directories : configuration_inc,
-  dependencies : [pulse, boost])
+  dependencies : [pulse, cxxopts])
 
 install_man('pamixer.1')

--- a/pamixer.cc
+++ b/pamixer.cc
@@ -19,8 +19,7 @@
 #include "pulseaudio.hh"
 #include "device.hh"
 
-#include <boost/program_options.hpp>
-namespace po = boost::program_options;
+#include <cxxopts.hpp>
 
 #include <cmath>
 #include <list>
@@ -32,8 +31,8 @@ using namespace std;
 
 
 
-void conflicting_options(const po::variables_map& vm, const char* opt1, const char* opt2);
-Device get_selected_device(Pulseaudio& pulse, po::variables_map vm, string sink_name, string source_name);
+void conflicting_options(const cxxopts::ParseResult& result, const char* opt1, const char* opt2);
+Device get_selected_device(Pulseaudio& pulse, const cxxopts::ParseResult& result, const string& sink_name, const string& source_name);
 int gammaCorrection(int i, double gamma, int delta);
 int main(int argc, char* argv[]);
 
@@ -41,21 +40,21 @@ int main(int argc, char* argv[]);
 
 /* Function used to check that 'opt1' and 'opt2' are not specified
    at the same time. */
-void conflicting_options(const po::variables_map& vm, const char* opt1, const char* opt2) {
-    if (vm.count(opt1) && !vm[opt1].defaulted()
-        && vm.count(opt2) && !vm[opt2].defaulted()) {
+void conflicting_options(const cxxopts::ParseResult& result, const char* opt1, const char* opt2) {
+    if (result.count(opt1) && !result[opt1].has_default()
+        && result.count(opt2) && !result[opt2].has_default()) {
 
         throw logic_error(string("Conflicting options '") + opt1 + "' and '" + opt2 + "'.");
     }
 }
 
-Device get_selected_device(Pulseaudio& pulse, po::variables_map vm, string sink_name, string source_name) {
+Device get_selected_device(Pulseaudio& pulse, const cxxopts::ParseResult& result, const string& sink_name, const string& source_name) {
     Device device = pulse.get_default_sink();
-    if (vm.count("sink")) {
+    if (result.count("sink")) {
         device = pulse.get_sink(sink_name);
-    } else if (vm.count("default-source")) {
+    } else if (result.count("default-source")) {
         device = pulse.get_default_source();
-    } else if (vm.count("source")) {
+    } else if (result.count("source")) {
         device = pulse.get_source(source_name);
     }
     return device;
@@ -96,24 +95,25 @@ int main(int argc, char* argv[])
     int value, limit_value;
     double gamma;
 
-    po::options_description options("Allowed options");
+    cxxopts::Options options("pamixer", "pulseaudio command line mixer");
+
     options.add_options()
-        ("help,h", "help message")
-        ("version,v", "print version info")
-        ("sink", po::value(&sink_name), "choose a different sink than the default")
-        ("source", po::value(&source_name), "choose a different source than the default")
+        ("h,help", "help message")
+        ("v,version", "print version info")
+        ("sink", "choose a different sink than the default", cxxopts::value<string>(sink_name))
+        ("source", "choose a different source than the default", cxxopts::value<string>(source_name))
         ("default-source", "select the default source")
         ("get-volume", "get the current volume")
         ("get-volume-human", "get the current volume percentage or the string \"muted\"")
-        ("set-volume", po::value<int>(&value), "set the volume")
-        ("increase,i", po::value<int>(&value), "increase the volume")
-        ("decrease,d", po::value<int>(&value), "decrease the volume")
-        ("toggle-mute,t", "switch between mute and unmute")
-        ("mute,m", "set mute")
+        ("set-volume", "set the volume", cxxopts::value<int>(value))
+        ("i,increase", "increase the volume", cxxopts::value<int>(value))
+        ("d,decrease", "decrease the volume", cxxopts::value<int>(value))
+        ("t,toggle-mute", "switch between mute and unmute")
+        ("m,mute", "set mute")
         ("allow-boost", "allow volume to go above 100%")
-        ("set-limit", po::value<int>(&limit_value), "set a limit for the volume")
-        ("gamma", po::value<double>(&gamma)->default_value(1.0), "increase/decrease using gamma correction e.g. 2.2")
-        ("unmute,u", "unset mute")
+        ("set-limit", "set a limit for the volume", cxxopts::value<int>(limit_value))
+        ("gamma", "increase/decrease using gamma correction e.g. 2.2", cxxopts::value<double>(gamma)->default_value("1.0"))
+        ("u,unmute", "unset mute")
         ("get-mute", "display true if the volume is mute, false otherwise")
         ("list-sinks", "list the sinks")
         ("list-sources", "list the sources")
@@ -122,66 +122,65 @@ int main(int argc, char* argv[])
 
     try
     {
-        po::variables_map vm;
-        po::store(po::parse_command_line(argc, argv, options), vm);
-        po::notify(vm);
+        auto result = options.parse(argc, argv);
 
-        if (vm.count("help") || vm.size() < 2) {
-            cout << options << endl;
+        // FIXME: print help message in case missing options
+        if (result.count("help")) {
+            cout << options.help() << endl;
             return 0;
         }
 
-        if (vm.count("version")) {
+        if (result.count("version")) {
             cout << VERSION << endl;
             return 0;
         }
 
-        conflicting_options(vm, "set-volume", "increase");
-        conflicting_options(vm, "set-volume", "decrease");
-        conflicting_options(vm, "decrease", "increase");
-        conflicting_options(vm, "toggle-mute", "mute");
-        conflicting_options(vm, "toggle-mute", "unmute");
-        conflicting_options(vm, "unmute", "mute");
-        conflicting_options(vm, "sink", "source");
-        conflicting_options(vm, "sink", "default-source");
-        conflicting_options(vm, "get-volume", "list-sinks");
-        conflicting_options(vm, "get-volume", "list-sources");
-        conflicting_options(vm, "get-volume", "get-volume-human");
-        conflicting_options(vm, "get-volume", "get-default-sink");
-        conflicting_options(vm, "get-volume-human", "list-sinks");
-        conflicting_options(vm, "get-volume-human", "list-sources");
-        conflicting_options(vm, "get-volume-human", "get-mute");
-        conflicting_options(vm, "get-volume-human", "get-default-sink");
-        conflicting_options(vm, "get-mute", "list-sinks");
-        conflicting_options(vm, "get-mute", "list-sources");
-        conflicting_options(vm, "get-mute", "get-default-sink");
+        conflicting_options(result, "set-volume", "increase");
+        conflicting_options(result, "set-volume", "decrease");
+        conflicting_options(result, "decrease", "increase");
+        conflicting_options(result, "toggle-mute", "mute");
+        conflicting_options(result, "toggle-mute", "unmute");
+        conflicting_options(result, "unmute", "mute");
+        conflicting_options(result, "sink", "source");
+        conflicting_options(result, "sink", "default-source");
+        conflicting_options(result, "get-volume", "list-sinks");
+        conflicting_options(result, "get-volume", "list-sources");
+        conflicting_options(result, "get-volume", "get-volume-human");
+        conflicting_options(result, "get-volume", "get-default-sink");
+        conflicting_options(result, "get-volume-human", "list-sinks");
+        conflicting_options(result, "get-volume-human", "list-sources");
+        conflicting_options(result, "get-volume-human", "get-mute");
+        conflicting_options(result, "get-volume-human", "get-default-sink");
+        conflicting_options(result, "get-mute", "list-sinks");
+        conflicting_options(result, "get-mute", "list-sources");
+        conflicting_options(result, "get-mute", "get-default-sink");
 
         Pulseaudio pulse("pamixer");
-        Device device = get_selected_device(pulse, vm, sink_name, source_name);
+        Device device = get_selected_device(pulse, result, sink_name, source_name);
 
-        if (vm.count("set-volume") || vm.count("increase") || vm.count("decrease")) {
+        if (result.count("set-volume") || result.count("increase") || result.count("decrease")) {
             if (value < 0) {
                 value = 0;
             }
 
             pa_volume_t new_value = 0;
-            if (vm.count("set-volume")) {
+            if (result.count("set-volume")) {
                 new_value = round( (double)value * (double)PA_VOLUME_NORM / 100.0);
-            } else if (vm.count("increase")) {
+            } else if (result.count("increase")) {
                 new_value = gammaCorrection(device.volume_avg, gamma,  value);
-            } else if (vm.count("decrease")) {
+            } else if (result.count("decrease")) {
                 new_value = gammaCorrection(device.volume_avg, gamma, -value);
             }
 
-            if (!vm.count("allow-boost") && new_value > PA_VOLUME_NORM) {
+            if (!result.count("allow-boost") && new_value > PA_VOLUME_NORM) {
                 new_value = PA_VOLUME_NORM;
             }
 
             pulse.set_volume(device, new_value);
-            device = get_selected_device(pulse, vm, sink_name, source_name);
+            device = get_selected_device(pulse, result, sink_name, source_name);
         }
 
-        if (vm.count("set-limit")) {
+        if (result.count("set-limit")) {
 
             if (limit_value < 0 ) {
                 limit_value = 0;
@@ -190,33 +189,33 @@ int main(int argc, char* argv[])
             pa_volume_t limit = round( (double)limit_value * (double)PA_VOLUME_NORM / 100.0);
             if (device.volume_avg > limit) {
                 pulse.set_volume(device, limit);
-                device = get_selected_device(pulse, vm, sink_name, source_name);
+                device = get_selected_device(pulse, result, sink_name, source_name);
             }
         }
 
-        if (vm.count("toggle-mute") || vm.count("mute") || vm.count("unmute")) {
-            if (vm.count("toggle-mute")) {
+        if (result.count("toggle-mute") || result.count("mute") || result.count("unmute")) {
+            if (result.count("toggle-mute")) {
                 pulse.set_mute(device, !device.mute);
             } else {
-                pulse.set_mute(device, vm.count("mute") || !vm.count("unmute"));
+                pulse.set_mute(device, result.count("mute") || !result.count("unmute"));
             }
-            device = get_selected_device(pulse, vm, sink_name, source_name);
+            device = get_selected_device(pulse, result, sink_name, source_name);
         }
 
-        if (vm.count("get-volume") && vm.count("get-mute")) {
+        if (result.count("get-volume") && result.count("get-mute")) {
             cout << boolalpha << device.mute << ' ' << device.volume_percent << '\n';
-        } else if (vm.count("get-volume")) {
+        } else if (result.count("get-volume")) {
             cout << device.volume_percent << '\n';
-        } else if (vm.count("get-volume-human")) {
+        } else if (result.count("get-volume-human")) {
             if (device.mute) {
                 cout << "muted\n";
             } else {
                 cout << device.volume_percent << "%\n";
             }
-        } else if (vm.count("get-mute")) {
+        } else if (result.count("get-mute")) {
             cout << boolalpha << device.mute << '\n';
         } else {
-            if (vm.count("list-sinks")) {
+            if (result.count("list-sinks")) {
                 cout << "Sinks:\n";
                 for (const Device& sink : pulse.get_sinks()) {
                     cout << sink.index << " \""
@@ -225,7 +224,7 @@ int main(int argc, char* argv[])
                          << sink.description << "\"\n";
                 }
             }
-            if (vm.count("list-sources")) {
+            if (result.count("list-sources")) {
                 cout << "Sources:\n";
                 for (const Device& source : pulse.get_sources()) {
                     cout << source.index << " \""
@@ -234,7 +233,7 @@ int main(int argc, char* argv[])
                          << source.description << "\"\n";
                 }
             }
-            if (vm.count("get-default-sink")) {
+            if (result.count("get-default-sink")) {
                 Device sink = pulse.get_default_sink();
                 cout << "Default sink:\n";
                 cout << sink.index << " \""
@@ -253,7 +252,7 @@ int main(int argc, char* argv[])
     catch (const std::exception& e)
     {
         cerr << argv[0] << ": " << e.what() << "\n\n";
-        cerr << options << '\n';
+        cerr << options.help() << '\n';
         return 2;
     }
 }


### PR DESCRIPTION
Fix issue #46

It's not really smaller (pamixer strip binary is a lot bigger 590k after compared to 109k before) but it remove a runtime dependency.