### PR TITLE
Add `--get-default-source` option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,31 +46,31 @@ Installation
         Usage:
           pamixer [OPTION...]
 
-          -h, --help              help message
-          -v, --version           print version info
-              --sink arg          choose a different sink than the default
-              --source arg        choose a different source than the default
-              --default-source    select the default source
-              --get-volume        get the current volume
-              --get-volume-human  get the current volume percentage or the string
-                                  "muted"
-              --set-volume arg    set the volume
-          -i, --increase arg      increase the volume
-          -d, --decrease arg      decrease the volume
-          -t, --toggle-mute       switch between mute and unmute
-          -m, --mute              set mute
-              --allow-boost       allow volume to go above 100%
-              --set-limit arg     set a limit for the volume
-              --gamma arg         increase/decrease using gamma correction e.g. 2.2
-                                  (default: 1.0)
-          -u, --unmute            unset mute
-              --get-mute          display true if the volume is mute, false
-                                  otherwise
-              --list-sinks        list the sinks
-              --list-sources      list the sources
-              --get-default-sink  print the default sink
+          -h, --help                help message
+          -v, --version             print version info
+              --sink arg            choose a different sink than the default
+              --source arg          choose a different source than the default
+              --default-source      select the default source
+              --get-volume          get the current volume
+              --get-volume-human    get the current volume percentage or the string
+                                    "muted"
+              --set-volume arg      set the volume
+          -i, --increase arg        increase the volume
+          -d, --decrease arg        decrease the volume
+          -t, --toggle-mute         switch between mute and unmute
+          -m, --mute                set mute
+              --allow-boost         allow volume to go above 100%
+              --set-limit arg       set a limit for the volume
+              --gamma arg           increase/decrease using gamma correction e.g. 2.2
+                                    (default: 1.0)
+          -u, --unmute              unset mute
+              --get-mute            display true if the volume is mute, false
+                                    otherwise
+              --list-sinks          list the sinks
+              --list-sources        list the sources
+              --get-default-sink    print the default sink
+              --get-default-source  print the default source
 
     * Or install it::
 
         meson install -C build
-

--- a/src/pamixer.cc
+++ b/src/pamixer.cc
@@ -118,6 +118,7 @@ int main(int argc, char* argv[])
         ("list-sinks", "list the sinks")
         ("list-sources", "list the sources")
         ("get-default-sink", "print the default sink")
+        ("get-default-source", "print the default source")
         ;
 
     try
@@ -147,13 +148,17 @@ int main(int argc, char* argv[])
         conflicting_options(result, "get-volume", "list-sources");
         conflicting_options(result, "get-volume", "get-volume-human");
         conflicting_options(result, "get-volume", "get-default-sink");
+        conflicting_options(result, "get-volume", "get-default-source");
         conflicting_options(result, "get-volume-human", "list-sinks");
         conflicting_options(result, "get-volume-human", "list-sources");
         conflicting_options(result, "get-volume-human", "get-mute");
         conflicting_options(result, "get-volume-human", "get-default-sink");
+        conflicting_options(result, "get-volume-human", "get-default-source");
         conflicting_options(result, "get-mute", "list-sinks");
         conflicting_options(result, "get-mute", "list-sources");
         conflicting_options(result, "get-mute", "get-default-sink");
+        conflicting_options(result, "get-mute", "get-default-source");
+        conflicting_options(result, "get-default-sink", "get-default-source");
 
         Pulseaudio pulse("pamixer");
         Device device = get_selected_device(pulse, result, sink_name, source_name);
@@ -239,6 +244,13 @@ int main(int argc, char* argv[])
                 cout << sink.index << " \""
                      << sink.name << "\" \""
                      << sink.description << "\"\n";
+            }
+            if (result.count("get-default-source")) {
+              Device source = pulse.get_default_source();
+              cout << "Default source:\n";
+              cout << source.index << " \""
+                   << source.name << "\" \""
+                   << source.description << "\"\n";
             }
         }
 


### PR DESCRIPTION
Similar to what `--get-default-sink` does, this option prints the index, name and description of the default source. Tested locally and working.

Closes #52.