### PR TITLE
add new listings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@
 *.xz
 *.gz
 .cache
+/build/
+
+.cproject
+
+.project

--- a/README.rst
+++ b/README.rst
@@ -70,8 +70,8 @@ Installation
                                   otherwise
               --list-sinks        list the sinks
               --list-sources      list the sources
-              --list-streams      list the streams
-              --list-sink-inputs  list the sink input 
+              --list-streams      list the sink/source of the stream when it was last seen
+              --list-sink-inputs  list the sink input from currently running clients
               --get-default-sink  print the default sink
 
     * Or install it::

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,8 @@ Features
 * Set the volume for the default sink, the default source or any other device
 * List the sinks
 * List the sources
+* List the streams
+* List the sink-inputs
 * Increase / Decrease the volume for a device (using gamma correction optionally)
 * Mute or unmute a device
 
@@ -68,6 +70,8 @@ Installation
                                   otherwise
               --list-sinks        list the sinks
               --list-sources      list the sources
+              --list-streams      list the streams
+              --list-sink-inputs  list the sink input 
               --get-default-sink  print the default sink
 
     * Or install it::

--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,7 @@ project('pamixer', 'cpp', version : '1.7-dev',
 src = files([
   'src/callbacks.cc',
   'src/device.cc',
+  'src/stream.cc',
   'src/pamixer.cc',
   'src/pulseaudio.cc'
 ])

--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,7 @@ src = files([
   'src/callbacks.cc',
   'src/device.cc',
   'src/stream.cc',
+  'src/sink-input.cc',
   'src/pamixer.cc',
   'src/pulseaudio.cc'
 ])

--- a/meson.build
+++ b/meson.build
@@ -3,6 +3,7 @@ project('pamixer', 'cpp', version : '1.7-dev',
 
 src = files([
   'src/callbacks.cc',
+  'src/basic-info.cc',
   'src/device.cc',
   'src/stream.cc',
   'src/sink-input.cc',

--- a/src/basic-info.cc
+++ b/src/basic-info.cc
@@ -1,6 +1,3 @@
-#ifndef STREAM_H
-#define STREAM_H
-
 /*
  * Copyright (C) 2022 m4sc
  *
@@ -18,21 +15,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <basic-info.hh>
-#include <pulse/pulseaudio.h>
+
+#include "basic-info.hh"
 #include <pulse/ext-stream-restore.h>
-#include <string>
+#include <cmath>
+#include <cstring>
+#include <iostream>
 
 
-/**
- * Class to store streams and used devices
- *
- * @see pa_ext_stream_restore_info
- */
-class Stream : public BasicInfo{
-public:
-    std::string device;
-    Stream(const pa_ext_stream_restore_info* i);    
-};
+void
+BasicInfo::setVolume(const pa_cvolume* v) {
+    volume         = *v;
+    volume_avg     = pa_cvolume_avg(v);
+    volume_percent = (int) round( (double)volume_avg * 100. / PA_VOLUME_NORM );
+}
 
-#endif
+
+

--- a/src/basic-info.hh
+++ b/src/basic-info.hh
@@ -1,5 +1,5 @@
-#ifndef STREAM_H
-#define STREAM_H
+#ifndef BINFO_H
+#define BINFO_H
 
 /*
  * Copyright (C) 2022 m4sc
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <basic-info.hh>
+
 #include <pulse/pulseaudio.h>
 #include <pulse/ext-stream-restore.h>
 #include <string>
@@ -29,10 +29,16 @@
  *
  * @see pa_ext_stream_restore_info
  */
-class Stream : public BasicInfo{
+class BasicInfo {
 public:
-    std::string device;
-    Stream(const pa_ext_stream_restore_info* i);    
+    std::string name;
+    pa_cvolume volume;
+    pa_volume_t volume_avg;
+    int volume_percent;
+    bool mute;
+
+protected:
+    void setVolume(const pa_cvolume* v);
 };
 
 #endif

--- a/src/callbacks.cc
+++ b/src/callbacks.cc
@@ -28,6 +28,15 @@ void sink_list_cb(pa_context * UNUSED(c), const pa_sink_info *i, int eol, void *
     sinks->push_back(s);
 }
 
+
+void stream_list_cb(pa_context * UNUSED(c), const pa_ext_stream_restore_info *i, int eol, void *raw) {
+    if (eol != 0) return;
+
+    std::list<Stream>* streams = (std::list<Stream>*) raw;
+    Stream st(i);
+    streams->push_back(st);
+}
+
 void source_list_cb(pa_context * UNUSED(c), const pa_source_info *i, int eol, void *raw) {
     if (eol != 0) return;
 

--- a/src/callbacks.cc
+++ b/src/callbacks.cc
@@ -28,6 +28,14 @@ void sink_list_cb(pa_context * UNUSED(c), const pa_sink_info *i, int eol, void *
     sinks->push_back(s);
 }
 
+void sink_input_list_cb(pa_context * UNUSED(c), const pa_sink_input_info* i, int eol, void *raw) {
+    if (eol != 0) return;
+
+    std::list<SinkInput>* sinks = (std::list<SinkInput>*) raw;
+    SinkInput s(i);
+    sinks->push_back(s);
+}
+
 
 void stream_list_cb(pa_context * UNUSED(c), const pa_ext_stream_restore_info *i, int eol, void *raw) {
     if (eol != 0) return;

--- a/src/callbacks.hh
+++ b/src/callbacks.hh
@@ -16,6 +16,7 @@
 
 void state_cb(pa_context* context, void* raw);
 void sink_list_cb(pa_context *c, const pa_sink_info *i, int eol, void *raw);
+void sink_input_list_cb(pa_context *c, const pa_sink_input_info *i, int eol, void *raw);
 void source_list_cb(pa_context *c, const pa_source_info *i, int eol, void *raw);
 void stream_list_cb(pa_context *context, const pa_ext_stream_restore_info *i, int eol, void *raw);
 void server_info_cb(pa_context* context, const pa_server_info* i, void* raw);

--- a/src/callbacks.hh
+++ b/src/callbacks.hh
@@ -2,6 +2,7 @@
 
 #include "pulseaudio.hh"
 #include <pulse/pulseaudio.h>
+#include <pulse/ext-stream-restore.h>
 
 #ifdef UNUSED
 #elif defined(__GNUC__)
@@ -16,6 +17,7 @@
 void state_cb(pa_context* context, void* raw);
 void sink_list_cb(pa_context *c, const pa_sink_info *i, int eol, void *raw);
 void source_list_cb(pa_context *c, const pa_source_info *i, int eol, void *raw);
+void stream_list_cb(pa_context *context, const pa_ext_stream_restore_info *i, int eol, void *raw);
 void server_info_cb(pa_context* context, const pa_server_info* i, void* raw);
 void success_cb(pa_context* context, int success, void* raw);
 

--- a/src/device.cc
+++ b/src/device.cc
@@ -51,11 +51,3 @@ Device::Device(const pa_sink_info* info) {
     }
     setVolume(&(info->volume));
 }
-
-
-void
-Device::setVolume(const pa_cvolume* v) {
-    volume         = *v;
-    volume_avg     = pa_cvolume_avg(v);
-    volume_percent = (int) round( (double)volume_avg * 100. / PA_VOLUME_NORM );
-}

--- a/src/device.hh
+++ b/src/device.hh
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
+#include <basic-info.hh>
 #include <pulse/pulseaudio.h>
 #include <string>
 
@@ -43,23 +43,15 @@ typedef enum device_state device_state_t;
  * @see pa_sink_info
  * @see pa_source_info
  */
-class Device {
+class Device : public BasicInfo{
 public:
     uint32_t index;
     device_type_t type;
-    std::string name;
     std::string description;
     device_state_t state;
-    pa_cvolume volume;
-    pa_volume_t volume_avg;
-    int volume_percent;
-    bool mute;
 
     Device(const pa_source_info* i);
     Device(const pa_sink_info* i);
-
-private:
-    void setVolume(const pa_cvolume* v);
 };
 
 #endif

--- a/src/pamixer.cc
+++ b/src/pamixer.cc
@@ -120,8 +120,8 @@ int main(int argc, char* argv[])
         ("list-sinks", "list the sinks")
         ("list-sources", "list the sources")
         ("get-default-sink", "print the default sink")
-        ("list-streams", "lists the streams")
-		("list-sink-inputs", "list of sink inputs")
+        ("list-streams", "list the sink/source of the stream when it was last seen")
+		("list-sink-inputs", "list the sink input from currently running clients")
         ;
 
     try

--- a/src/pamixer.cc
+++ b/src/pamixer.cc
@@ -167,10 +167,12 @@ int main(int argc, char* argv[])
         conflicting_options(result, "sink", "default-source");
         conflicting_options(result, "get-volume", "list-sinks");
         conflicting_options(result, "get-volume", "list-sources");
+        conflicting_options(result, "get-volume", "list-sinks");
         conflicting_options(result, "get-volume", "get-volume-human");
         conflicting_options(result, "get-volume", "get-default-sink");
         conflicting_options(result, "get-volume-human", "list-sinks");
         conflicting_options(result, "get-volume-human", "list-sources");
+        conflicting_options(result, "get-volume-human", "list-sinks");
         conflicting_options(result, "get-volume-human", "get-mute");
         conflicting_options(result, "get-volume-human", "get-default-sink");
         conflicting_options(result, "get-mute", "list-sinks");
@@ -254,14 +256,18 @@ int main(int argc, char* argv[])
             }
             if (result.count("list-streams")) {
                 for (const Stream& stream : pulse.get_streams()) {
-                    cout << stream.name << "\" \""
+                    cout << stream.name << " \""
                          << stream.device << "\" \""
                          << stream.mute << "\"\n";
                 }
             }
             if (result.count("list-sink-inputs")) {
                 for (const SinkInput& inputs : pulse.get_sink_inputs()) {
-                    cout << inputs.name << "\" \""
+                    cout << inputs.index << " \""
+                    	 << inputs.name << "\" \""
+						 << inputs.sink << "\" \""
+						 << inputs.client << "\" \""
+						 << inputs.volume_percent << "\" \""
                          << inputs.mute << "\"\n";
                 }
             }

--- a/src/pamixer.cc
+++ b/src/pamixer.cc
@@ -139,6 +139,7 @@ int main(int argc, char* argv[])
         ("list-sources", "list the sources")
         ("get-default-sink", "print the default sink")
         ("list-streams", "lists the streams")
+		("list-sink-inputs", "list of sink inputs")
         ;
 
     try
@@ -256,6 +257,12 @@ int main(int argc, char* argv[])
                     cout << stream.name << "\" \""
                          << stream.device << "\" \""
                          << stream.mute << "\"\n";
+                }
+            }
+            if (result.count("list-sink-inputs")) {
+                for (const SinkInput& inputs : pulse.get_sink_inputs()) {
+                    cout << inputs.name << "\" \""
+                         << inputs.mute << "\"\n";
                 }
             }
         }

--- a/src/pamixer.cc
+++ b/src/pamixer.cc
@@ -90,24 +90,6 @@ pa_volume_t gammaCorrection(pa_volume_t i, double gamma, int delta) {
     return (pa_volume_t) round(j);
 }
 
-/*
-* prints devices on the standard output
-*
-* Format: "index" "name" "status" "description" "mute"
-*   status: Running, Idle, Suspended, Invalid state
-*   mute: 0, 1 
-*
-* @param devices list of devices (sinks, sources, sinks + sources)
-*/
-void printDevices(std::list<Device> devices) {
-    for (const Device& device : devices) {
-        cout << device.index << " \""
-             << device.name << "\" \""
-             << device_state_to_string(device) << "\" \""
-             << device.description << "\" \""
-             << device.mute << "\"\n";
-    }
-}
 
 int main(int argc, char* argv[])
 {
@@ -167,16 +149,20 @@ int main(int argc, char* argv[])
         conflicting_options(result, "sink", "default-source");
         conflicting_options(result, "get-volume", "list-sinks");
         conflicting_options(result, "get-volume", "list-sources");
-        conflicting_options(result, "get-volume", "list-sinks");
+        conflicting_options(result, "get-volume", "list-sink-inputs");
+        conflicting_options(result, "get-volume", "list-streams");
         conflicting_options(result, "get-volume", "get-volume-human");
         conflicting_options(result, "get-volume", "get-default-sink");
         conflicting_options(result, "get-volume-human", "list-sinks");
         conflicting_options(result, "get-volume-human", "list-sources");
-        conflicting_options(result, "get-volume-human", "list-sinks");
+        conflicting_options(result, "get-volume-human", "list-sink-inputs");
+        conflicting_options(result, "get-volume-human", "list-streams");
         conflicting_options(result, "get-volume-human", "get-mute");
         conflicting_options(result, "get-volume-human", "get-default-sink");
         conflicting_options(result, "get-mute", "list-sinks");
         conflicting_options(result, "get-mute", "list-sources");
+        conflicting_options(result, "get-mute", "list-streams");
+		conflicting_options(result, "get-mute", "list-sink-inputs");
         conflicting_options(result, "get-mute", "get-default-sink");
 
         Pulseaudio pulse("pamixer");
@@ -238,15 +224,30 @@ int main(int argc, char* argv[])
             }
         } else if (result.count("get-mute")) {
             cout << boolalpha << device.mute << '\n';
-        } else {
-            if (result.count("list-sinks")) {
-                cout << "Sinks:\n";
-                printDevices(pulse.get_sinks());                
-            }
-            if (result.count("list-sources")) {
-                cout << "Sources:\n";
-                printDevices(pulse.get_sources());                
-            }
+		} else {
+			if (result.count("list-sinks")) {
+				cout << "Sinks:\n";
+				for (const Device &sink : pulse.get_sinks()) {
+					cout << sink.index << " \""
+						 << sink.name << "\" \""
+						 << device_state_to_string(sink) << "\" \""
+						 << sink.description << "\" \""
+						 << sink.mute << "\" \""
+						 << sink.volume_percent << "\"\n";
+				}
+			}
+			if (result.count("list-sources")) {
+				cout << "Sources:\n";
+				for (const Device &source : pulse.get_sources()) {
+					cout << source.index << " \""
+						 << source.name << "\" \""
+						 << device_state_to_string(source) << "\" \""
+						 << source.description << "\" \""
+						 << source.mute << "\" \""
+						 << source.volume_percent << "\"\n";
+				}
+
+			}
             if (result.count("get-default-sink")) {
                 Device sink = pulse.get_default_sink();
                 cout << "Default sink:\n";
@@ -255,13 +256,16 @@ int main(int argc, char* argv[])
                      << sink.description << "\"\n";
             }
             if (result.count("list-streams")) {
+            	cout << "Stored Streams:\n";
                 for (const Stream& stream : pulse.get_streams()) {
                     cout << stream.name << " \""
                          << stream.device << "\" \""
+						 << stream.volume_percent << "\" \""
                          << stream.mute << "\"\n";
                 }
             }
             if (result.count("list-sink-inputs")) {
+            	cout << "Sink Inputs:\n";
                 for (const SinkInput& inputs : pulse.get_sink_inputs()) {
                     cout << inputs.index << " \""
                     	 << inputs.name << "\" \""

--- a/src/pamixer.cc
+++ b/src/pamixer.cc
@@ -18,6 +18,7 @@
 #include <config.hh>
 #include "pulseaudio.hh"
 #include "device.hh"
+#include "stream.hh"
 
 #include <cxxopts.hpp>
 
@@ -89,6 +90,25 @@ pa_volume_t gammaCorrection(pa_volume_t i, double gamma, int delta) {
     return (pa_volume_t) round(j);
 }
 
+/*
+* prints devices on the standard output
+*
+* Format: "index" "name" "status" "description" "mute"
+*   status: Running, Idle, Suspended, Invalid state
+*   mute: 0, 1 
+*
+* @param devices list of devices (sinks, sources, sinks + sources)
+*/
+void printDevices(std::list<Device> devices) {
+    for (const Device& device : devices) {
+        cout << device.index << " \""
+             << device.name << "\" \""
+             << device_state_to_string(device) << "\" \""
+             << device.description << "\" \""
+             << device.mute << "\"\n";
+    }
+}
+
 int main(int argc, char* argv[])
 {
     string sink_name, source_name;
@@ -118,6 +138,7 @@ int main(int argc, char* argv[])
         ("list-sinks", "list the sinks")
         ("list-sources", "list the sources")
         ("get-default-sink", "print the default sink")
+        ("list-streams", "lists the streams")
         ;
 
     try
@@ -217,21 +238,11 @@ int main(int argc, char* argv[])
         } else {
             if (result.count("list-sinks")) {
                 cout << "Sinks:\n";
-                for (const Device& sink : pulse.get_sinks()) {
-                    cout << sink.index << " \""
-                         << sink.name << "\" \""
-                         << device_state_to_string(sink) << "\" \""
-                         << sink.description << "\"\n";
-                }
+                printDevices(pulse.get_sinks());                
             }
             if (result.count("list-sources")) {
                 cout << "Sources:\n";
-                for (const Device& source : pulse.get_sources()) {
-                    cout << source.index << " \""
-                         << source.name << "\" \""
-                         << device_state_to_string(source) << "\" \""
-                         << source.description << "\"\n";
-                }
+                printDevices(pulse.get_sources());                
             }
             if (result.count("get-default-sink")) {
                 Device sink = pulse.get_default_sink();
@@ -239,6 +250,13 @@ int main(int argc, char* argv[])
                 cout << sink.index << " \""
                      << sink.name << "\" \""
                      << sink.description << "\"\n";
+            }
+            if (result.count("list-streams")) {
+                for (const Stream& stream : pulse.get_streams()) {
+                    cout << stream.name << "\" \""
+                         << stream.device << "\" \""
+                         << stream.mute << "\"\n";
+                }
             }
         }
 

--- a/src/pulseaudio.cc
+++ b/src/pulseaudio.cc
@@ -81,6 +81,11 @@ Pulseaudio::get_sources() {
     return sources;
 }
 
+/**
+ * stored streams for specific clients
+ *
+ * including stored sink and volume
+ */
 std::list<Stream>
 Pulseaudio::get_streams(){
     std::list<Stream> streams;
@@ -92,6 +97,11 @@ Pulseaudio::get_streams(){
     return streams;
 }
 
+/**
+ * current running sink inputs
+ *
+ * including client, used sink, volume ...
+ */
 std::list<SinkInput>
 Pulseaudio::get_sink_inputs() {
     std::list<SinkInput> sinkInputs;

--- a/src/pulseaudio.cc
+++ b/src/pulseaudio.cc
@@ -92,6 +92,16 @@ Pulseaudio::get_streams(){
     return streams;
 }
 
+std::list<SinkInput>
+Pulseaudio::get_sink_inputs() {
+    std::list<SinkInput> sinkInputs;
+    pa_operation* op = pa_context_get_sink_input_info_list(context, &sink_input_list_cb, &sinkInputs);
+    iterate(op);
+    pa_operation_unref(op);
+
+    return sinkInputs;
+}
+
 Device
 Pulseaudio::get_sink(uint32_t index) {
     std::list<Device> sinks;

--- a/src/pulseaudio.cc
+++ b/src/pulseaudio.cc
@@ -81,11 +81,6 @@ Pulseaudio::get_sources() {
     return sources;
 }
 
-/**
- * stored streams for specific clients
- *
- * including stored sink and volume
- */
 std::list<Stream>
 Pulseaudio::get_streams(){
     std::list<Stream> streams;
@@ -97,11 +92,6 @@ Pulseaudio::get_streams(){
     return streams;
 }
 
-/**
- * current running sink inputs
- *
- * including client, used sink, volume ...
- */
 std::list<SinkInput>
 Pulseaudio::get_sink_inputs() {
     std::list<SinkInput> sinkInputs;

--- a/src/pulseaudio.cc
+++ b/src/pulseaudio.cc
@@ -81,6 +81,17 @@ Pulseaudio::get_sources() {
     return sources;
 }
 
+std::list<Stream>
+Pulseaudio::get_streams(){
+    std::list<Stream> streams;
+    pa_operation* op = pa_ext_stream_restore_read(context, &stream_list_cb, &streams);
+
+    iterate(op);
+    pa_operation_unref(op);
+
+    return streams;
+}
+
 Device
 Pulseaudio::get_sink(uint32_t index) {
     std::list<Device> sinks;

--- a/src/pulseaudio.hh
+++ b/src/pulseaudio.hh
@@ -83,8 +83,14 @@ public:
      */
     std::list<Device> get_sources();
 
+    /**
+     * @return list of the previously stored sinks, sources and clients
+     */
     std::list<Stream> get_streams();
 
+    /**
+     * @return list of the running sink inputs
+     */
     std::list<SinkInput>get_sink_inputs();
 
     /**

--- a/src/pulseaudio.hh
+++ b/src/pulseaudio.hh
@@ -25,6 +25,7 @@
 
 #include "device.hh"
 #include "stream.hh"
+#include "sink-input.hh"
 
 #include "callbacks.hh"
 
@@ -83,6 +84,8 @@ public:
     std::list<Device> get_sources();
 
     std::list<Stream> get_streams();
+
+    std::list<SinkInput>get_sink_inputs();
 
     /**
      * Get a specific sink

--- a/src/pulseaudio.hh
+++ b/src/pulseaudio.hh
@@ -24,6 +24,8 @@
 #include <list>
 
 #include "device.hh"
+#include "stream.hh"
+
 #include "callbacks.hh"
 
 
@@ -79,6 +81,8 @@ public:
      * @return list of the available sources
      */
     std::list<Device> get_sources();
+
+    std::list<Stream> get_streams();
 
     /**
      * Get a specific sink

--- a/src/sink-input.cc
+++ b/src/sink-input.cc
@@ -25,12 +25,18 @@
 
 
 SinkInput::SinkInput(const pa_sink_input_info* info) {
+
 	name   = info->name;
 	index = info->index;
     mute   = info->mute == 1;
     client = info->client;
     sink = info->sink;
+
+    setVolume(&(info->volume));
 }
+
+
+
 
 
 

--- a/src/sink-input.cc
+++ b/src/sink-input.cc
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 m4sc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "sink-input.hh"
+#include <pulse/ext-stream-restore.h>
+#include <cmath>
+#include <cstring>
+#include <iostream>
+
+
+
+SinkInput::SinkInput(const pa_sink_input_info* info) {
+	name   = info->name;
+	index = info->index;
+    mute   = info->mute == 1;
+    client = info->client;
+    sink = info->sink;
+}
+
+
+

--- a/src/sink-input.hh
+++ b/src/sink-input.hh
@@ -1,0 +1,43 @@
+#ifndef SINKINPUT_H
+#define SINKINPUT_H
+
+/*
+ * Copyright (C) 2022 m4sc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <pulse/pulseaudio.h>
+#include <pulse/ext-stream-restore.h>
+#include <string>
+
+
+/**
+ * Class to store streams and used devices
+ *
+ * @see pa_ext_stream_restore_info
+ */
+class SinkInput {
+public:
+	uint32_t index;
+    std::string name;
+    uint32_t client;
+    uint32_t sink;
+    bool mute;
+
+    SinkInput(const pa_sink_input_info* i);
+};
+
+#endif

--- a/src/sink-input.hh
+++ b/src/sink-input.hh
@@ -18,24 +18,23 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
+#include <basic-info.hh>
 #include <pulse/pulseaudio.h>
 #include <pulse/ext-stream-restore.h>
 #include <string>
 
 
 /**
- * Class to store streams and used devices
+ * Class to store sink inputs including
+ * client which uses the sink
  *
- * @see pa_ext_stream_restore_info
+ * @see pa_sink_input_info
  */
-class SinkInput {
+class SinkInput : public BasicInfo{
 public:
 	uint32_t index;
-    std::string name;
     uint32_t client;
     uint32_t sink;
-    bool mute;
 
     SinkInput(const pa_sink_input_info* i);
 };

--- a/src/stream.cc
+++ b/src/stream.cc
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022 m4sc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "stream.hh"
+#include <pulse/ext-stream-restore.h>
+#include <cmath>
+#include <cstring>
+#include <iostream>
+
+
+
+Stream::Stream(const pa_ext_stream_restore_info* info) {
+	name   = info->name;
+	//NULL handling as the device for the stream can point to 0x0
+	if(info->device) device = info->device;
+    mute   = info->mute == 1;
+}
+
+
+

--- a/src/stream.cc
+++ b/src/stream.cc
@@ -25,11 +25,14 @@
 
 
 Stream::Stream(const pa_ext_stream_restore_info* info) {
-	name   = info->name;
+	mute = info->mute == 1;
+	name = info->name;
 	//NULL handling as the device for the stream can point to 0x0
 	if(info->device) device = info->device;
-    mute   = info->mute == 1;
+
+    setVolume(&(info->volume));
 }
+
 
 
 

--- a/src/stream.hh
+++ b/src/stream.hh
@@ -33,6 +33,7 @@ class Stream : public BasicInfo{
 public:
 	/** The sink source of the stream when it was last seen */
     std::string device;
+
     Stream(const pa_ext_stream_restore_info* i);    
 };
 

--- a/src/stream.hh
+++ b/src/stream.hh
@@ -31,6 +31,7 @@
  */
 class Stream : public BasicInfo{
 public:
+	/** The sink source of the stream when it was last seen */
     std::string device;
     Stream(const pa_ext_stream_restore_info* i);    
 };

--- a/src/stream.hh
+++ b/src/stream.hh
@@ -1,0 +1,41 @@
+#ifndef STREAM_H
+#define STREAM_H
+
+/*
+ * Copyright (C) 2022 m4sc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <pulse/pulseaudio.h>
+#include <pulse/ext-stream-restore.h>
+#include <string>
+
+
+/**
+ * Class to store streams and used devices
+ *
+ * @see pa_ext_stream_restore_info
+ */
+class Stream {
+public:
+    std::string name;
+    std::string device;
+    bool mute;
+
+    Stream(const pa_ext_stream_restore_info* i);    
+};
+
+#endif


### PR DESCRIPTION
For a new project, I need to list and modify also streams and sink-inputs therefore:

Add new options:
--list-streams      list the sink/source of the stream when it was last seen
--list-sink-inputs  list the sink input from currently running clients

- Introduce new storage classes for streams and sink inputs
- refactor properties and functions(name, volume... , mute) which are used in all "storage" classes (extends BasicInfo)

- add volume_percent for the list-sources and list-sinks options (maybe unwanted regarding backward compatibility)

Not to have a BIG merge and maybe get some feedback on conventions or best practice starting with the listings...